### PR TITLE
Added support for NUnit custom name tests from TestCaseSource attribute.

### DIFF
--- a/src/BaseAllureAttribute.cs
+++ b/src/BaseAllureAttribute.cs
@@ -22,7 +22,7 @@ namespace NUnit.Allure
                 var testResult = new TestResult
                 {
                     uuid = test.Id,
-                    name = test.MethodName,
+                    name = test.Name,
                     fullName = test.FullName,
                     labels = new List<Label>
                     {

--- a/src/SampleTests.cs
+++ b/src/SampleTests.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using Allure.Commons;
 using NUnit.Allure.Attributes;
 using NUnit.Framework;
+using NUnit.Framework.Interfaces;
 
 namespace NUnit.Allure
 {
@@ -86,6 +88,23 @@ namespace NUnit.Allure
         public void Xxx3()
         {
             Assert.Pass();
+        }
+
+        [Test, TestCaseSource("GetCustomNameTests")]
+        [AllureTest]
+        public void CustomNames(bool data)
+        {
+            Assert.IsTrue(data);
+        }
+
+        public static IEnumerable<ITestCaseData> GetCustomNameTests
+        {
+            get
+            {
+                yield return new TestCaseData(true).SetName("Custom_1");
+                yield return new TestCaseData(true).SetName("Custom_2");
+                yield return new TestCaseData(false).SetName("Custom_3");
+            }
         }
     }
 }


### PR DESCRIPTION
Added a fix for tests, fetched from TestCaseSources with custom names. 
This way, dynamic tests are not displayed with same name on Allure reports

![image](https://user-images.githubusercontent.com/33682314/33083612-831c1af0-cee8-11e7-8c3b-f4436e28394d.png)
