### PR TITLE
fixed AllureExtendedConfiguration not created from AllureConfiguration

### DIFF
--- a/src/allure-nunit/Core/AllureExtendedConfiguration.cs
+++ b/src/allure-nunit/Core/AllureExtendedConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Allure.Commons.Configuration;
+using Newtonsoft.Json;
 
 namespace NUnit.Allure.Core
 {
@@ -7,6 +8,7 @@ namespace NUnit.Allure.Core
     {
         public HashSet<string> BrokenTestData { get; set; } = new HashSet<string>();
 
+        [JsonConstructor]
         protected AllureExtendedConfiguration(string title, string directory, HashSet<string> links) : base(title,
             directory, links)
         {


### PR DESCRIPTION
Problem: all failed tests in Allure report were marked as broken, even if 'BrokenTestData' was correctly set in AllureConfiguration json.
Reason: exception when creating AllureExtendedConfiguration from ` var config = allureSection?.ToObject<AllureExtendedConfiguration>();`
Exception:
Unable to find a constructor to use for type NUnit.Allure.Core.AllureExtendedConfiguration. A class should either have a default constructor, one constructor with arguments or a constructor marked with the JsonConstructor attribute. Path 'allure.directory', line 1, position 23.
Solution: Add [JsonConstructor] attribute to AllureExtendedConfiguration constructor