### PR TITLE
Logic related to updating of Test Result moved to Attributes level

### DIFF
--- a/src/allure-nunit/Attributes/AllureEpicAttribute.cs
+++ b/src/allure-nunit/Attributes/AllureEpicAttribute.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using NUnit.Framework;
+using Allure.Commons;
 
 namespace NUnit.Allure.Attributes
 {
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true)]
-    public class AllureEpicAttribute : NUnitAttribute
+    public class AllureEpicAttribute : AllureTestCaseAttribute
     {
         public AllureEpicAttribute(string epic)
         {
@@ -12,5 +12,10 @@ namespace NUnit.Allure.Attributes
         }
 
         public string Epic { get; }
+
+        public override void UpdateTestResult(TestResult testResult)
+        {
+            testResult.labels.Add(Label.Epic(Epic));
+        }
     }
 }

--- a/src/allure-nunit/Attributes/AllureFeatureAttribute.cs
+++ b/src/allure-nunit/Attributes/AllureFeatureAttribute.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using NUnit.Framework;
+using Allure.Commons;
 
 namespace NUnit.Allure.Attributes
 {
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true)]
-    public class AllureFeatureAttribute : NUnitAttribute
+    public class AllureFeatureAttribute : AllureTestCaseAttribute
     {
         public AllureFeatureAttribute(params string[] feature)
         {
@@ -12,5 +12,11 @@ namespace NUnit.Allure.Attributes
         }
 
         internal string[] Features { get; }
+
+        public override void UpdateTestResult(TestResult testResult)
+        {
+            foreach (var feature in Features)
+                testResult.labels.Add(Label.Feature(feature));
+        }
     }
 }

--- a/src/allure-nunit/Attributes/AllureIssueAttribute.cs
+++ b/src/allure-nunit/Attributes/AllureIssueAttribute.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using Allure.Commons;
-using NUnit.Framework;
 
 namespace NUnit.Allure.Attributes
 {
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true)]
-    public class AllureIssueAttribute : NUnitAttribute
+    public class AllureIssueAttribute : AllureTestCaseAttribute
     {
         public AllureIssueAttribute(string name, string url)
         {
@@ -18,5 +17,10 @@ namespace NUnit.Allure.Attributes
         }
 
         internal Link IssueLink { get; }
+
+        public override void UpdateTestResult(TestResult testCaseResult)
+        {
+            testCaseResult.links.Add(IssueLink);
+        }
     }
 }

--- a/src/allure-nunit/Attributes/AllureLabelAttribute.cs
+++ b/src/allure-nunit/Attributes/AllureLabelAttribute.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using NUnit.Framework;
+using Allure.Commons;
 
 namespace NUnit.Allure.Attributes
 {
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true)]
-    public class AllureLabelAttribute : NUnitAttribute
+    public class AllureLabelAttribute : AllureTestCaseAttribute
     {
         public AllureLabelAttribute(string name, string value)
         {
@@ -14,5 +14,10 @@ namespace NUnit.Allure.Attributes
 
         internal string Name { get; }
         internal string Value { get; }
+
+        public override void UpdateTestResult(TestResult testResult)
+        {
+            testResult.labels.Add(new Label { name = Name, value = Value });
+        }
     }
 }

--- a/src/allure-nunit/Attributes/AllureLinkAttribute.cs
+++ b/src/allure-nunit/Attributes/AllureLinkAttribute.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using Allure.Commons;
-using NUnit.Framework;
 
 namespace NUnit.Allure.Attributes
 {
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true)]
-    public class AllureLinkAttribute : NUnitAttribute
+    public class AllureLinkAttribute : AllureTestCaseAttribute
     {
         public AllureLinkAttribute(string name, string url)
         {
@@ -18,5 +17,10 @@ namespace NUnit.Allure.Attributes
         }
 
         internal Link Link { get; }
+
+        public override void UpdateTestResult(TestResult testResult)
+        {
+            testResult.links.Add(Link);
+        }
     }
 }

--- a/src/allure-nunit/Attributes/AllureOwnerAttribute.cs
+++ b/src/allure-nunit/Attributes/AllureOwnerAttribute.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using NUnit.Framework;
+using Allure.Commons;
 
 namespace NUnit.Allure.Attributes
 {
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true)]
-    public class AllureOwnerAttribute : NUnitAttribute
+    public class AllureOwnerAttribute : AllureTestCaseAttribute
     {
         public AllureOwnerAttribute(string owner)
         {
@@ -12,5 +12,10 @@ namespace NUnit.Allure.Attributes
         }
 
         internal string Owner { get; }
+
+        public override void UpdateTestResult(TestResult testResult)
+        {
+            testResult.labels.Add(Label.Owner(Owner));
+        }
     }
 }

--- a/src/allure-nunit/Attributes/AllureParentSuiteAttribute.cs
+++ b/src/allure-nunit/Attributes/AllureParentSuiteAttribute.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using NUnit.Framework;
+using Allure.Commons;
 
 namespace NUnit.Allure.Attributes
 {
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true)]
-    public class AllureParentSuiteAttribute : NUnitAttribute
+    public class AllureParentSuiteAttribute : AllureTestCaseAttribute
     {
         public AllureParentSuiteAttribute(string parentSuite)
         {
@@ -12,5 +12,10 @@ namespace NUnit.Allure.Attributes
         }
 
         internal string ParentSuite { get; }
+
+        public override void UpdateTestResult(TestResult testResult)
+        {
+            testResult.labels.Add(Label.ParentSuite(ParentSuite));
+        }
     }
 }

--- a/src/allure-nunit/Attributes/AllureSeverityAttribute.cs
+++ b/src/allure-nunit/Attributes/AllureSeverityAttribute.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using Allure.Commons;
-using NUnit.Framework;
 
 namespace NUnit.Allure.Attributes
 {
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
-    public class AllureSeverityAttribute : NUnitAttribute
+    public class AllureSeverityAttribute : AllureTestCaseAttribute
     {
         public AllureSeverityAttribute(SeverityLevel severity = SeverityLevel.normal)
         {
@@ -13,5 +12,10 @@ namespace NUnit.Allure.Attributes
         }
 
         internal SeverityLevel Severity { get; }
+
+        public override void UpdateTestResult(TestResult testCaseResult)
+        {
+            testCaseResult.labels.Add(Label.Severity(Severity));
+        }
     }
 }

--- a/src/allure-nunit/Attributes/AllureStoryAttribute.cs
+++ b/src/allure-nunit/Attributes/AllureStoryAttribute.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using NUnit.Framework;
+using Allure.Commons;
 
 namespace NUnit.Allure.Attributes
 {
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true)]
-    public class AllureStoryAttribute : NUnitAttribute
+    public class AllureStoryAttribute : AllureTestCaseAttribute
     {
         public AllureStoryAttribute(params string[] story)
         {
@@ -12,5 +12,11 @@ namespace NUnit.Allure.Attributes
         }
 
         internal string[] Stories { get; }
+
+        public override void UpdateTestResult(TestResult testResult)
+        {
+            foreach (var story in Stories)
+                testResult.labels.Add(Label.Story(story));
+        }
     }
 }

--- a/src/allure-nunit/Attributes/AllureSubSuiteAttribute.cs
+++ b/src/allure-nunit/Attributes/AllureSubSuiteAttribute.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using NUnit.Framework;
+using Allure.Commons;
 
 namespace NUnit.Allure.Attributes
 {
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true)]
-    public class AllureSubSuiteAttribute : NUnitAttribute
+    public class AllureSubSuiteAttribute : AllureTestCaseAttribute
     {
         public AllureSubSuiteAttribute(string subSuite)
         {
@@ -12,5 +12,10 @@ namespace NUnit.Allure.Attributes
         }
 
         internal string SubSuite { get; }
+
+        public override void UpdateTestResult(TestResult testResult)
+        {
+            testResult.labels.Add(Label.SubSuite(SubSuite));
+        }
     }
 }

--- a/src/allure-nunit/Attributes/AllureSuiteAttribute.cs
+++ b/src/allure-nunit/Attributes/AllureSuiteAttribute.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using NUnit.Framework;
+using Allure.Commons;
 
 namespace NUnit.Allure.Attributes
 {
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true)]
-    public class AllureSuiteAttribute : NUnitAttribute
+    public class AllureSuiteAttribute : AllureTestCaseAttribute
     {
         public AllureSuiteAttribute(string suite)
         {
@@ -12,5 +12,10 @@ namespace NUnit.Allure.Attributes
         }
 
         internal string Suite { get; }
+
+        public override void UpdateTestResult(TestResult testResult)
+        {
+            testResult.labels.Add(Label.Suite(Suite));
+        }
     }
 }

--- a/src/allure-nunit/Attributes/AllureTagAttribute.cs
+++ b/src/allure-nunit/Attributes/AllureTagAttribute.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using NUnit.Framework;
+using Allure.Commons;
 
 namespace NUnit.Allure.Attributes
 {
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true)]
-    public class AllureTagAttribute : NUnitAttribute
+    public class AllureTagAttribute : AllureTestCaseAttribute
     {
         public AllureTagAttribute(params string[] tags)
         {
@@ -12,5 +12,11 @@ namespace NUnit.Allure.Attributes
         }
 
         internal string[] Tags { get; }
+
+        public override void UpdateTestResult(TestResult testResult)
+        {
+            foreach (var tag in Tags)
+                testResult.labels.Add(Label.Tag(tag));
+        }
     }
 }

--- a/src/allure-nunit/Attributes/AllureTestCaseAttribute.cs
+++ b/src/allure-nunit/Attributes/AllureTestCaseAttribute.cs
@@ -1,0 +1,10 @@
+﻿using Allure.Commons;
+using NUnit.Framework;
+
+namespace NUnit.Allure.Attributes
+{
+    public abstract class AllureTestCaseAttribute : NUnitAttribute
+    {
+        public abstract void UpdateTestResult(TestResult testResult);
+    }
+}

--- a/src/allure-nunit/Attributes/AllureTmsAttribute.cs
+++ b/src/allure-nunit/Attributes/AllureTmsAttribute.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using Allure.Commons;
-using NUnit.Framework;
 
 namespace NUnit.Allure.Attributes
 {
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true)]
-    public class AllureTmsAttribute : NUnitAttribute
+    public class AllureTmsAttribute : AllureTestCaseAttribute
     {
         public AllureTmsAttribute(string name, string url)
         {
@@ -18,5 +17,10 @@ namespace NUnit.Allure.Attributes
         }
 
         internal Link TmsLink { get; }
+
+        public override void UpdateTestResult(TestResult testResult)
+        {
+            testResult.links.Add(TmsLink);
+        }
     }
 }

--- a/src/allure-nunit/Core/AllureNUnitHelper.cs
+++ b/src/allure-nunit/Core/AllureNUnitHelper.cs
@@ -331,58 +331,13 @@ namespace NUnit.Allure.Core
             foreach (var p in GetTestProperties(PropertyNames.Category))
                 AllureLifecycle.UpdateTestCase(x => x.labels.Add(Label.Tag(p)));
 
-            var attributes = _test.Method.GetCustomAttributes<NUnitAttribute>(true).ToList();
-            attributes.AddRange(GetTestFixture(_test).GetCustomAttributes<NUnitAttribute>(true).ToList());
+            var attributes = _test.Method.GetCustomAttributes<AllureTestCaseAttribute>(true).ToList();
+            attributes.AddRange(GetTestFixture(_test).GetCustomAttributes<AllureTestCaseAttribute>(true).ToList());
 
-            foreach (var attribute in attributes)
-                switch (attribute)
-                {
-                    case AllureFeatureAttribute featureAttr:
-                        foreach (var feature in featureAttr.Features)
-                            AllureLifecycle.UpdateTestCase(x => x.labels.Add(Label.Feature(feature)));
-                        break;
-                    case AllureIssueAttribute issueAttr:
-                        AllureLifecycle.UpdateTestCase(x => x.links.Add(issueAttr.IssueLink));
-                        break;
-                    case AllureSeverityAttribute severityAttr:
-                        AllureLifecycle.UpdateTestCase(
-                            x => x.labels.Add(Label.Severity(severityAttr.Severity)));
-                        break;
-                    case AllureStoryAttribute storyAttr:
-                        foreach (var story in storyAttr.Stories)
-                            AllureLifecycle.UpdateTestCase(x => x.labels.Add(Label.Story(story)));
-                        break;
-                    case AllureTagAttribute tagAttr:
-                        foreach (var tag in tagAttr.Tags)
-                            AllureLifecycle.UpdateTestCase(x => x.labels.Add(Label.Tag(tag)));
-                        break;
-                    case AllureTmsAttribute tmsAttr:
-                        AllureLifecycle.UpdateTestCase(x => x.links.Add(tmsAttr.TmsLink));
-                        break;
-                    case AllureLinkAttribute linkAttr:
-                        AllureLifecycle.UpdateTestCase(x => x.links.Add(linkAttr.Link));
-                        break;
-                    case AllureSuiteAttribute suiteAttr:
-                        AllureLifecycle.UpdateTestCase(x => x.labels.Add(Label.Suite(suiteAttr.Suite)));
-                        break;
-                    case AllureSubSuiteAttribute subSuiteAttr:
-                        AllureLifecycle.UpdateTestCase(
-                            x => x.labels.Add(Label.SubSuite(subSuiteAttr.SubSuite)));
-                        break;
-                    case AllureOwnerAttribute ownerAttr:
-                        AllureLifecycle.UpdateTestCase(x => x.labels.Add(Label.Owner(ownerAttr.Owner)));
-                        break;
-                    case AllureLabelAttribute labelAttr:
-                        AllureLifecycle.UpdateTestCase(x => x.labels.Add(new Label{name =  labelAttr.Name, value = labelAttr.Value}));
-                        break;
-                    case AllureEpicAttribute epicAttr:
-                        AllureLifecycle.UpdateTestCase(x => x.labels.Add(Label.Epic(epicAttr.Epic)));
-                        break;
-                    case AllureParentSuiteAttribute parentSuiteAttr:
-                        AllureLifecycle.UpdateTestCase(x =>
-                            x.labels.Add(Label.ParentSuite(parentSuiteAttr.ParentSuite)));
-                        break;
-                }
+            attributes.ForEach(a =>
+            {
+                AllureLifecycle.UpdateTestCase(a.UpdateTestResult);
+            });
         }
 
         private IEnumerable<string> GetTestProperties(string name)


### PR DESCRIPTION
Logic related to updating of Test Result moved to Attributes level. 
This allows go away from the hardcoded list of available attributes and creates an extension point. Consumers will be able to create custom Attributes for updating Test Result.