### PR TITLE
When there is no message from the underlying failure exception e need…

### DIFF
--- a/src/allure-nunit/Core/AllureNUnitHelper.cs
+++ b/src/allure-nunit/Core/AllureNUnitHelper.cs
@@ -252,7 +252,9 @@ namespace NUnit.Allure.Core
 
             AllureLifecycle.UpdateTestCase(x => x.statusDetails = new StatusDetails
             {
-                message = TestContext.CurrentContext.Result.Message,
+                message = string.IsNullOrWhiteSpace(TestContext.CurrentContext.Result.Message)
+                ? TestContext.CurrentContext.Test.Name 
+                : TestContext.CurrentContext.Result.Message,
                 trace = TestContext.CurrentContext.Result.StackTrace
             });
 


### PR DESCRIPTION
When there is no message from the underlying failure exception e need to substitute String.Empty for something else meaningful.

![image](https://user-images.githubusercontent.com/239825/121156418-02a0c780-c88c-11eb-857f-a71ddbad7f3a.png)
